### PR TITLE
feat: added lives system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ out/
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 
+# Eclipse-specific files
+.classpath
+.project
+.settings/
+
 # JIRA plugin
 atlassian-ide-plugin.xml
 

--- a/src/main/java/dev/emortal/minestom/minesweeper/board/Board.java
+++ b/src/main/java/dev/emortal/minestom/minesweeper/board/Board.java
@@ -73,8 +73,7 @@ public final class Board {
 
     public boolean isRevealed(int x, int y) {
         Block block = this.instance.getBlock(x, MapManager.FLOOR_HEIGHT, y, Block.Getter.Condition.TYPE);
-        if (block == null)
-            return false;
+        if (block == null) return false;
 
         return isRevealed(block);
     }
@@ -89,8 +88,7 @@ public final class Board {
 
     public boolean isFlagged(int x, int y) {
         Block block = this.instance.getBlock(x, MapManager.FLOOR_HEIGHT + 1, y, Block.Getter.Condition.TYPE);
-        if (block == null)
-            return false;
+        if (block == null) return false;
         return isFlagged(block);
     }
 
@@ -102,8 +100,7 @@ public final class Board {
         int unrevealed = 0;
         for (int x = 0; x < height; x++) {
             for (int y = 0; y < width; y++) {
-                if (!isRevealed(x, y))
-                    unrevealed++;
+                if (!isRevealed(x, y)) unrevealed++;
             }
         }
 
@@ -111,8 +108,7 @@ public final class Board {
     }
 
     public boolean isSolved(Chunk chunk) {
-        if (solvedChunks.contains(new Vec2(chunk.getChunkX(), chunk.getChunkZ())))
-            return true;
+        if (solvedChunks.contains(new Vec2(chunk.getChunkX(), chunk.getChunkZ()))) return true;
 
         for (int x = 0; x < Chunk.CHUNK_SIZE_X; x++) {
             for (int y = 0; y < Chunk.CHUNK_SIZE_Z; y++) {
@@ -154,8 +150,7 @@ public final class Board {
         for (Direction8 direction : Direction8.VALUES) {
             int newX = x + direction.offsetX();
             int newY = y + direction.offsetY();
-            if (this.isOutOfBounds(newX, newY))
-                continue;
+            if (this.isOutOfBounds(newX, newY)) continue;
 
             if (this.isMine(newX, newY)) {
                 mines++;
@@ -167,8 +162,7 @@ public final class Board {
 
     public void reveal(int x, int y, Block.Setter blockSetter) {
         boolean mine = isMine(x, y);
-        if (mine)
-            return;
+        if (mine) return;
 
         blockSetter.setBlock(x, MapManager.FLOOR_HEIGHT, y, this.theme.nothing());
 
@@ -192,31 +186,26 @@ public final class Board {
         affectedChunks.add(chunk);
 
         byte minesAround1 = getMinesAround(x, y);
-        if (minesAround1 > 0)
-            return;
+        if (minesAround1 > 0) return;
 
         for (Direction8 direction : Direction8.VALUES) {
             int newX = x + direction.offsetX();
             int newY = y + direction.offsetY();
 
-            if (this.isOutOfBounds(newX, newY))
-                continue;
-            if (this.isRevealed(newX, newY))
-                continue;
+            if (this.isOutOfBounds(newX, newY)) continue;
+            if (this.isRevealed(newX, newY)) continue;
 
             this.revealAround(newX, newY, affectedChunks);
         }
     }
 
     public boolean isOutOfBounds(int x, int y) {
-        if (infinite)
-            return false;
+        if (infinite) return false;
         return x < 0 || x >= height || y < 0 || y >= width;
     }
 
     public void populateWithMines(Chunk chunk) {
-        if (chunk.hasTag(POPULATED_TAG))
-            return; // already populated
+        if (chunk.hasTag(POPULATED_TAG)) return; // already populated
 
         double base = 0.09;
         long dx = Math.abs(chunk.getChunkX());
@@ -224,8 +213,7 @@ public final class Board {
         long chebyshev = Math.max(dx, dz);
 
         double difficulty = base + (chebyshev * 0.01);
-        if (difficulty > 0.19)
-            difficulty = 0.19;
+        if (difficulty > 0.19) difficulty = 0.19;
 
         populateWithMines(chunk, difficulty);
     }
@@ -246,8 +234,7 @@ public final class Board {
 
             i++;
 
-            if (isMine(x, y))
-                continue;
+            if (isMine(x, y)) continue;
 
             addMine(x, y);
 
@@ -265,10 +252,8 @@ public final class Board {
                     for (int relY = 0; relY < Chunk.CHUNK_SIZE_Z; relY++) {
                         int y = chunk.getChunkZ() * Chunk.CHUNK_SIZE_Z + relY;
 
-                        if (isOutOfBounds(x, y))
-                            continue;
-                        if (!isMine(x, y))
-                            continue;
+                        if (isOutOfBounds(x, y)) continue;
+                        if (!isMine(x, y)) continue;
                         batch.setBlock(x, MapManager.FLOOR_HEIGHT, y, this.theme.mine());
                     }
                 }
@@ -324,8 +309,7 @@ public final class Board {
         chunk.sendChunk();
 
         Set<Vec2> flags = chunk.getTag(FLAGS_TAG);
-        if (flags == null)
-            return;
+        if (flags == null) return;
         flags.remove(pos);
     }
 

--- a/src/main/java/dev/emortal/minestom/minesweeper/board/Board.java
+++ b/src/main/java/dev/emortal/minestom/minesweeper/board/Board.java
@@ -44,6 +44,7 @@ public final class Board {
         this.instance = instance;
         this.theme = theme;
     }
+
     public Board(int width, int height, long seed, @NotNull Instance instance, @NotNull MapTheme theme) {
         this.infinite = false;
         this.width = width;
@@ -72,7 +73,8 @@ public final class Board {
 
     public boolean isRevealed(int x, int y) {
         Block block = this.instance.getBlock(x, MapManager.FLOOR_HEIGHT, y, Block.Getter.Condition.TYPE);
-        if (block == null) return false;
+        if (block == null)
+            return false;
 
         return isRevealed(block);
     }
@@ -81,9 +83,14 @@ public final class Board {
         return block.compare(this.theme.nothing());
     }
 
+    public Block getFlag(int x, int y) {
+        return this.instance.getBlock(x, MapManager.FLOOR_HEIGHT + 1, y);
+    }
+
     public boolean isFlagged(int x, int y) {
         Block block = this.instance.getBlock(x, MapManager.FLOOR_HEIGHT + 1, y, Block.Getter.Condition.TYPE);
-        if (block == null) return false;
+        if (block == null)
+            return false;
         return isFlagged(block);
     }
 
@@ -95,7 +102,8 @@ public final class Board {
         int unrevealed = 0;
         for (int x = 0; x < height; x++) {
             for (int y = 0; y < width; y++) {
-                if (!isRevealed(x, y)) unrevealed++;
+                if (!isRevealed(x, y))
+                    unrevealed++;
             }
         }
 
@@ -103,7 +111,8 @@ public final class Board {
     }
 
     public boolean isSolved(Chunk chunk) {
-        if (solvedChunks.contains(new Vec2(chunk.getChunkX(), chunk.getChunkZ()))) return true;
+        if (solvedChunks.contains(new Vec2(chunk.getChunkX(), chunk.getChunkZ())))
+            return true;
 
         for (int x = 0; x < Chunk.CHUNK_SIZE_X; x++) {
             for (int y = 0; y < Chunk.CHUNK_SIZE_Z; y++) {
@@ -145,7 +154,8 @@ public final class Board {
         for (Direction8 direction : Direction8.VALUES) {
             int newX = x + direction.offsetX();
             int newY = y + direction.offsetY();
-            if (this.isOutOfBounds(newX, newY)) continue;
+            if (this.isOutOfBounds(newX, newY))
+                continue;
 
             if (this.isMine(newX, newY)) {
                 mines++;
@@ -157,7 +167,8 @@ public final class Board {
 
     public void reveal(int x, int y, Block.Setter blockSetter) {
         boolean mine = isMine(x, y);
-        if (mine) return;
+        if (mine)
+            return;
 
         blockSetter.setBlock(x, MapManager.FLOOR_HEIGHT, y, this.theme.nothing());
 
@@ -181,26 +192,31 @@ public final class Board {
         affectedChunks.add(chunk);
 
         byte minesAround1 = getMinesAround(x, y);
-        if (minesAround1 > 0) return;
+        if (minesAround1 > 0)
+            return;
 
         for (Direction8 direction : Direction8.VALUES) {
             int newX = x + direction.offsetX();
             int newY = y + direction.offsetY();
 
-            if (this.isOutOfBounds(newX, newY)) continue;
-            if (this.isRevealed(newX, newY)) continue;
+            if (this.isOutOfBounds(newX, newY))
+                continue;
+            if (this.isRevealed(newX, newY))
+                continue;
 
             this.revealAround(newX, newY, affectedChunks);
         }
     }
 
     public boolean isOutOfBounds(int x, int y) {
-        if (infinite) return false;
+        if (infinite)
+            return false;
         return x < 0 || x >= height || y < 0 || y >= width;
     }
 
     public void populateWithMines(Chunk chunk) {
-        if (chunk.hasTag(POPULATED_TAG)) return; // already populated
+        if (chunk.hasTag(POPULATED_TAG))
+            return; // already populated
 
         double base = 0.09;
         long dx = Math.abs(chunk.getChunkX());
@@ -208,7 +224,8 @@ public final class Board {
         long chebyshev = Math.max(dx, dz);
 
         double difficulty = base + (chebyshev * 0.01);
-        if (difficulty > 0.19) difficulty = 0.19;
+        if (difficulty > 0.19)
+            difficulty = 0.19;
 
         populateWithMines(chunk, difficulty);
     }
@@ -229,7 +246,8 @@ public final class Board {
 
             i++;
 
-            if (isMine(x, y)) continue;
+            if (isMine(x, y))
+                continue;
 
             addMine(x, y);
 
@@ -247,8 +265,10 @@ public final class Board {
                     for (int relY = 0; relY < Chunk.CHUNK_SIZE_Z; relY++) {
                         int y = chunk.getChunkZ() * Chunk.CHUNK_SIZE_Z + relY;
 
-                        if (isOutOfBounds(x, y)) continue;
-                        if (!isMine(x, y)) continue;
+                        if (isOutOfBounds(x, y))
+                            continue;
+                        if (!isMine(x, y))
+                            continue;
                         batch.setBlock(x, MapManager.FLOOR_HEIGHT, y, this.theme.mine());
                     }
                 }
@@ -304,7 +324,8 @@ public final class Board {
         chunk.sendChunk();
 
         Set<Vec2> flags = chunk.getTag(FLAGS_TAG);
-        if (flags == null) return;
+        if (flags == null)
+            return;
         flags.remove(pos);
     }
 

--- a/src/main/java/dev/emortal/minestom/minesweeper/board/BoardReader.java
+++ b/src/main/java/dev/emortal/minestom/minesweeper/board/BoardReader.java
@@ -102,7 +102,8 @@ public class BoardReader {
     }
 
     static void assertThat(boolean condition, @NotNull String message) {
-        if (!condition) throw new Error(message);
+        if (!condition)
+            throw new Error(message);
     }
 
     public static class Error extends RuntimeException {

--- a/src/main/java/dev/emortal/minestom/minesweeper/board/BoardReader.java
+++ b/src/main/java/dev/emortal/minestom/minesweeper/board/BoardReader.java
@@ -102,8 +102,7 @@ public class BoardReader {
     }
 
     static void assertThat(boolean condition, @NotNull String message) {
-        if (!condition)
-            throw new Error(message);
+        if (!condition) throw new Error(message);
     }
 
     public static class Error extends RuntimeException {

--- a/src/main/java/dev/emortal/minestom/minesweeper/view/ActionBar.java
+++ b/src/main/java/dev/emortal/minestom/minesweeper/view/ActionBar.java
@@ -22,17 +22,14 @@ public final class ActionBar {
         this.startTime = System.currentTimeMillis();
 
         // Keep action bar shown
-        this.instance.scheduler()
-                .buildTask(this::update)
-                .repeat(TaskSchedule.tick(20))
-                .schedule();
+        this.instance.scheduler().buildTask(this::update).repeat(TaskSchedule.tick(20)).schedule();
     }
 
     public void incrementLives() {
         if (this.lives < 3) {
             this.lives++;
+            this.update();
         }
-        this.update();
     }
 
     public int decrementLives() {
@@ -56,13 +53,11 @@ public final class ActionBar {
         Duration duration = Duration.ofMillis(now - this.startTime);
 
         // ☠ {mines} MINES | ⚑ {flags} FLAGS | ⌚ 1m 23s
-        this.instance.sendActionBar(Component.text()
-                .append(Component.text("⚑ ", NamedTextColor.GREEN))
+        this.instance.sendActionBar(Component.text().append(Component.text("⚑ ", NamedTextColor.GREEN))
                 .append(Component.text(this.flags, NamedTextColor.GREEN))
                 .append(Component.text(" FLAGS", NamedTextColor.GREEN))
                 .append(Component.text(" | ", NamedTextColor.DARK_GRAY))
-                .append(Component.text("♥ ", NamedTextColor.RED))
-                .append(Component.text(this.lives, NamedTextColor.RED))
+                .append(Component.text("♥ ", NamedTextColor.RED)).append(Component.text(this.lives, NamedTextColor.RED))
                 .append(Component.text(" LIVES", NamedTextColor.RED))
                 .append(Component.text(" | ", NamedTextColor.DARK_GRAY))
                 .append(Component.text("⌚ ", NamedTextColor.AQUA))

--- a/src/main/java/dev/emortal/minestom/minesweeper/view/ActionBar.java
+++ b/src/main/java/dev/emortal/minestom/minesweeper/view/ActionBar.java
@@ -2,6 +2,9 @@ package dev.emortal.minestom.minesweeper.view;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.title.Title;
+import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.timer.TaskSchedule;
 import org.jetbrains.annotations.NotNull;
@@ -14,9 +17,11 @@ public final class ActionBar {
     private final long startTime;
 
     private int flags;
+    private int lives;
 
     public ActionBar(@NotNull Instance instance) {
         this.instance = instance;
+        this.lives = 3;
         this.startTime = System.currentTimeMillis();
 
         // Keep action bar shown
@@ -24,6 +29,19 @@ public final class ActionBar {
                 .buildTask(this::update)
                 .repeat(TaskSchedule.tick(20))
                 .schedule();
+    }
+
+    public void incrementLives() {
+        if (this.lives < 3) {
+            this.lives++;
+        }
+        this.update();
+    }
+
+    public int decrementLives() {
+        this.lives--;
+        this.update();
+        return this.lives;
     }
 
     public void incrementFlags() {
@@ -45,6 +63,10 @@ public final class ActionBar {
                 .append(Component.text("⚑ ", NamedTextColor.GREEN))
                 .append(Component.text(this.flags, NamedTextColor.GREEN))
                 .append(Component.text(" FLAGS", NamedTextColor.GREEN))
+                .append(Component.text(" | ", NamedTextColor.DARK_GRAY))
+                .append(Component.text("♥ ", NamedTextColor.RED))
+                .append(Component.text(this.lives, NamedTextColor.RED))
+                .append(Component.text(" LIVES", NamedTextColor.RED))
                 .append(Component.text(" | ", NamedTextColor.DARK_GRAY))
                 .append(Component.text("⌚ ", NamedTextColor.AQUA))
                 .append(Component.text(this.formatDuration(duration), NamedTextColor.AQUA)));

--- a/src/main/java/dev/emortal/minestom/minesweeper/view/ActionBar.java
+++ b/src/main/java/dev/emortal/minestom/minesweeper/view/ActionBar.java
@@ -2,9 +2,6 @@ package dev.emortal.minestom.minesweeper.view;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextDecoration;
-import net.kyori.adventure.title.Title;
-import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.timer.TaskSchedule;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/dev/emortal/minestom/minesweeper/view/InteractionManager.java
+++ b/src/main/java/dev/emortal/minestom/minesweeper/view/InteractionManager.java
@@ -49,8 +49,7 @@ public final class InteractionManager {
 
     private void onBreak(@NotNull PlayerBlockBreakEvent event) {
         event.setCancelled(true); // We never actually want to break the block
-        if (this.finished)
-            return;
+        if (this.finished) return;
 
         Player player = event.getPlayer();
 
@@ -59,14 +58,10 @@ public final class InteractionManager {
         int y = pos.blockY();
         int z = pos.blockZ();
 
-        if (this.isOutsideBoard(x, y, z))
-            return;
-        if (this.board.isFlagged(x, z))
-            return;
-        if (this.board.isRevealed(x, z))
-            return;
-        if (!player.getItemInMainHand().isAir())
-            return;
+        if (this.isOutsideBoard(x, y, z)) return;
+        if (this.board.isFlagged(x, z)) return;
+        if (this.board.isRevealed(x, z)) return;
+        if (!player.getItemInMainHand().isAir()) return;
 
         if (this.board.isMine(x, z)) {
             if (this.firstClick) {
@@ -81,15 +76,13 @@ public final class InteractionManager {
         this.firstClick = false;
 
         Chunk chunk = player.getInstance().getChunkAt(pos);
-        if (chunk == null)
-            return;
+        if (chunk == null) return;
 
         this.board.addClick(new Vec2(x, z), chunk);
         Set<Chunk> affectedChunks = this.board.revealAround(x, z);
 
         for (Chunk affectedChunk : affectedChunks) {
-            if (affectedChunk == null)
-                continue;
+            if (affectedChunk == null) continue;
 
             affectedChunk.sendChunk();
 
@@ -111,24 +104,20 @@ public final class InteractionManager {
         // This makes the logic significantly easier, rather than having to cancel
         // everywhere separately, and risking missing something
         event.setCancelled(true);
-        if (this.finished)
-            return;
+        if (this.finished) return;
 
         Player player = event.getPlayer();
         Point pos = event.getBlockPosition();
         Chunk chunk = event.getInstance().getChunkAt(pos);
-        if (chunk == null)
-            return;
+        if (chunk == null) return;
 
         int x = pos.blockX();
         int y = pos.blockY();
         int z = pos.blockZ();
 
-        if (event.getHand() != PlayerHand.MAIN)
-            return;
+        if (event.getHand() != PlayerHand.MAIN) return;
         if (!player.getItemInMainHand().isAir()) {
-            // This avoids players being able to place anything other than the carpets that
-            // get placed when they click with an empty hand
+            // This avoids players being able to place anything other than the carpets that get placed when they click with an empty hand
             return;
         }
 
@@ -146,8 +135,7 @@ public final class InteractionManager {
             return;
         }
 
-        if (this.isInvalidFlag(x, y, z))
-            return;
+        if (this.isInvalidFlag(x, y, z)) return;
 
         player.playSound(Sound.sound(SoundEvent.ENTITY_ENDER_DRAGON_FLAP, Sound.Source.MASTER, 0.6F, 2F));
         this.actionBar.incrementFlags();
@@ -156,8 +144,7 @@ public final class InteractionManager {
     }
 
     private void onItemChange(@NotNull InventoryItemChangeEvent event) {
-        // This is used to stop players from being able to take items out of the
-        // creative inventory
+        // This is used to stop players from being able to take items out of the creative inventory
         event.getInventory().setItemStack(event.getSlot(), ItemStack.AIR);
     }
 
@@ -214,30 +201,24 @@ public final class InteractionManager {
     }
 
     private boolean isOutsideBoard(int x, int y, int z) {
-        if (this.board.isOutOfBounds(x, z))
-            return true;
+        if (this.board.isOutOfBounds(x, z)) return true;
         return y != MapManager.FLOOR_HEIGHT;
     }
 
     private void playRevealSound(@NotNull Audience audience) {
-        audience.playSound(Sound.sound(SoundEvent.ENTITY_ITEM_PICKUP, Sound.Source.MASTER, 0.5F, 0.7F),
-                Sound.Emitter.self());
+        audience.playSound(Sound.sound(SoundEvent.ENTITY_ITEM_PICKUP, Sound.Source.MASTER, 0.5F, 0.7F), Sound.Emitter.self());
     }
 
     private void playSolvedChunkSound(@NotNull Audience audience) {
-        audience.playSound(Sound.sound(SoundEvent.ENTITY_PLAYER_LEVELUP, Sound.Source.MASTER, 0.5F, 1F),
-                Sound.Emitter.self());
+        audience.playSound(Sound.sound(SoundEvent.ENTITY_PLAYER_LEVELUP, Sound.Source.MASTER, 0.5F, 1F), Sound.Emitter.self());
     }
 
     private void playMineSound(@NotNull Audience audience) {
-        audience.playSound(Sound.sound(SoundEvent.ENTITY_GENERIC_EXPLODE, Sound.Source.MASTER, 4F, 0.84F),
-                Sound.Emitter.self());
+        audience.playSound(Sound.sound(SoundEvent.ENTITY_GENERIC_EXPLODE, Sound.Source.MASTER, 4F, 0.84F), Sound.Emitter.self());
     }
 
     private void playWinSounds(@NotNull Audience audience) {
-        audience.playSound(Sound.sound(SoundEvent.ENTITY_VILLAGER_CELEBRATE, Sound.Source.MASTER, 1F, 1F),
-                Sound.Emitter.self());
-        audience.playSound(Sound.sound(SoundEvent.ENTITY_PLAYER_LEVELUP, Sound.Source.MASTER, 1F, 1F),
-                Sound.Emitter.self());
+        audience.playSound(Sound.sound(SoundEvent.ENTITY_VILLAGER_CELEBRATE, Sound.Source.MASTER, 1F, 1F), Sound.Emitter.self());
+        audience.playSound(Sound.sound(SoundEvent.ENTITY_PLAYER_LEVELUP, Sound.Source.MASTER, 1F, 1F), Sound.Emitter.self());
     }
 }

--- a/src/main/java/dev/emortal/minestom/minesweeper/view/InteractionManager.java
+++ b/src/main/java/dev/emortal/minestom/minesweeper/view/InteractionManager.java
@@ -117,14 +117,15 @@ public final class InteractionManager {
 
         if (event.getHand() != PlayerHand.MAIN) return;
         if (!player.getItemInMainHand().isAir()) {
-            // This avoids players being able to place anything other than the carpets that get placed when they click with an empty hand
+            // This avoids players being able to place anything other than the carpets that
+            // get placed when they click with an empty hand
             return;
         }
 
         // If the block is already carpet (a flag), we want to remove the flag
         if (this.board.isFlagged(x, z)) {
-            if (!(this.board.getFlag(x, z) == Block.BLACK_CARPET)
-                    && (!this.board.getSolvedChunks().contains(new Vec2(chunk.getChunkX(), chunk.getChunkZ())))) {
+            if ((this.board.getFlag(x, z) != Block.BLACK_CARPET)
+                    && !this.board.getSolvedChunks().contains(new Vec2(chunk.getChunkX(), chunk.getChunkZ()))) {
                 // But only if it is not from a lost life or a completed chunk
                 player.playSound(Sound.sound(SoundEvent.ENTITY_ITEM_PICKUP, Sound.Source.MASTER, 0.6F, 1.8F));
                 this.actionBar.decrementFlags();
@@ -144,7 +145,8 @@ public final class InteractionManager {
     }
 
     private void onItemChange(@NotNull InventoryItemChangeEvent event) {
-        // This is used to stop players from being able to take items out of the creative inventory
+        // This is used to stop players from being able to take items out of the
+        // creative inventory
         event.getInventory().setItemStack(event.getSlot(), ItemStack.AIR);
     }
 
@@ -157,7 +159,7 @@ public final class InteractionManager {
     private void solveChunk(Chunk chunk) {
         this.board.revealSolved(chunk);
         this.board.addSolvedChunk(chunk);
-        playSolvedChunkSound(this.board.getInstance());
+        this.playSolvedChunkSound(this.board.getInstance());
 
         this.solvedChunks += 1;
 
@@ -172,10 +174,8 @@ public final class InteractionManager {
 
         this.board.addFlag(new Vec2(x, z), chunk, Block.BLACK_CARPET);
 
-        Component lossMessage = Component.text()
-                .append(Component.text(player.getUsername(), NamedTextColor.RED))
-                .append(Component.text(" clicked a bomb :\\", NamedTextColor.GRAY))
-                .build();
+        Component lossMessage = Component.text().append(Component.text(player.getUsername(), NamedTextColor.RED))
+                .append(Component.text(" clicked a bomb :\\", NamedTextColor.GRAY)).build();
 
         for (Player gamePlayer : this.game.getPlayers()) {
             this.playMineSound(gamePlayer);
@@ -206,19 +206,24 @@ public final class InteractionManager {
     }
 
     private void playRevealSound(@NotNull Audience audience) {
-        audience.playSound(Sound.sound(SoundEvent.ENTITY_ITEM_PICKUP, Sound.Source.MASTER, 0.5F, 0.7F), Sound.Emitter.self());
+        audience.playSound(Sound.sound(SoundEvent.ENTITY_ITEM_PICKUP, Sound.Source.MASTER, 0.5F, 0.7F),
+                Sound.Emitter.self());
     }
 
     private void playSolvedChunkSound(@NotNull Audience audience) {
-        audience.playSound(Sound.sound(SoundEvent.ENTITY_PLAYER_LEVELUP, Sound.Source.MASTER, 0.5F, 1F), Sound.Emitter.self());
+        audience.playSound(Sound.sound(SoundEvent.ENTITY_PLAYER_LEVELUP, Sound.Source.MASTER, 0.5F, 1F),
+                Sound.Emitter.self());
     }
 
     private void playMineSound(@NotNull Audience audience) {
-        audience.playSound(Sound.sound(SoundEvent.ENTITY_GENERIC_EXPLODE, Sound.Source.MASTER, 4F, 0.84F), Sound.Emitter.self());
+        audience.playSound(Sound.sound(SoundEvent.ENTITY_GENERIC_EXPLODE, Sound.Source.MASTER, 4F, 0.84F),
+                Sound.Emitter.self());
     }
 
     private void playWinSounds(@NotNull Audience audience) {
-        audience.playSound(Sound.sound(SoundEvent.ENTITY_VILLAGER_CELEBRATE, Sound.Source.MASTER, 1F, 1F), Sound.Emitter.self());
-        audience.playSound(Sound.sound(SoundEvent.ENTITY_PLAYER_LEVELUP, Sound.Source.MASTER, 1F, 1F), Sound.Emitter.self());
+        audience.playSound(Sound.sound(SoundEvent.ENTITY_VILLAGER_CELEBRATE, Sound.Source.MASTER, 1F, 1F),
+                Sound.Emitter.self());
+        audience.playSound(Sound.sound(SoundEvent.ENTITY_PLAYER_LEVELUP, Sound.Source.MASTER, 1F, 1F),
+                Sound.Emitter.self());
     }
 }

--- a/src/main/java/dev/emortal/minestom/minesweeper/view/InteractionManager.java
+++ b/src/main/java/dev/emortal/minestom/minesweeper/view/InteractionManager.java
@@ -132,12 +132,16 @@ public final class InteractionManager {
             return;
         }
 
+        // If the block is already carpet (a flag), we want to remove the flag
         if (this.board.isFlagged(x, z)) {
-            // If the block is already carpet (a flag), we want to remove the flag
-            player.playSound(Sound.sound(SoundEvent.ENTITY_ITEM_PICKUP, Sound.Source.MASTER, 0.6F, 1.8F));
-            this.actionBar.decrementFlags();
+            if (!(this.board.getFlag(x, z) == Block.BLACK_CARPET)
+                    && (!this.board.getSolvedChunks().contains(new Vec2(chunk.getChunkX(), chunk.getChunkZ())))) {
+                // But only if it is not from a lost life or a completed chunk
+                player.playSound(Sound.sound(SoundEvent.ENTITY_ITEM_PICKUP, Sound.Source.MASTER, 0.6F, 1.8F));
+                this.actionBar.decrementFlags();
 
-            this.board.removeFlag(new Vec2(x, z), chunk);
+                this.board.removeFlag(new Vec2(x, z), chunk);
+            }
 
             return;
         }


### PR DESCRIPTION
## Overview
This PR adds a lives system to make Minesweeper more forgiving.

## Details
- Players start with 3 lives, and the game ends once all lives are lost.
- Each mistake costs 1 life.
- Every 3 chunks cleared restores 1 life (up to a maximum of 3).
- Mistakes are marked with a black carpet until the chunk is completed.
